### PR TITLE
"0" instead of "nothing yet"

### DIFF
--- a/contents/ui/appcounter.qml
+++ b/contents/ui/appcounter.qml
@@ -13,7 +13,7 @@ import org.kde.kwindowsystem 1.0 as KWindowSystem
 Item {
     id: root
 
-    property string text: "nothing yet"
+    property string text: "0"
     property string deskSep: "~"
     property string totSep: "/"
 


### PR DESCRIPTION
For me "nothing yet" was even truncated and appeared as "ing ye"; I solved this by using "0" instead. PRing in case you are interested too. Cheers